### PR TITLE
Static site generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
+dist-ssr/
 dry_run/
 /scripts/serviceAccountKey.json

--- a/dummy.js
+++ b/dummy.js
@@ -1,0 +1,1 @@
+// Dummy module to avoid loading firebase/analytics during prerendering.

--- a/generate.ts
+++ b/generate.ts
@@ -1,0 +1,76 @@
+import * as fse from 'fs-extra'
+import * as path from 'path'
+import { renderToString } from '@vue/server-renderer'
+import * as firebase from 'firebase/app'
+import 'firebase/database'
+
+const firebaseConfig = {
+  apiKey: 'AIzaSyDY9ZeVVWzdIPQL12vKAN_SxWsazxo63SU',
+  authDomain: 'illust-ktsn-dev.firebaseapp.com',
+  databaseURL: 'https://illust-ktsn-dev.firebaseio.com',
+  projectId: 'illust-ktsn-dev',
+  storageBucket: 'illust-ktsn-dev.appspot.com',
+  messagingSenderId: '182006812020',
+  appId: '1:182006812020:web:d39a3fba26465f39c9f021',
+  measurementId: 'G-1JNZFCG5YL',
+}
+
+firebase.initializeApp(firebaseConfig)
+export const db = firebase.database()
+
+interface GenerateOptions {
+  baseHtmlPath: string
+  outputDir: string
+  routes: () => Promise<string[]>
+}
+
+async function generatePages(options: GenerateOptions) {
+  const ssrBundlePath = (await fse.readdir('dist-ssr')).find((f) =>
+    f.endsWith('.js')
+  )!
+  const { createApp } = require('./' + path.join('dist-ssr', ssrBundlePath))
+
+  const baseHtml = await fse.readFile(options.baseHtmlPath, 'utf8')
+  const dir = options.outputDir
+  const routes = await options.routes()
+
+  await Promise.all(
+    routes.map(async (route) => {
+      const { app, router } = createApp(true)
+      await router.push(route)
+      const content = await renderToString(app)
+
+      const replacedHtml = baseHtml.replace(
+        '<div id="app"></div>',
+        `<div id="app">${content}</div>`
+      )
+      const output = path.join(dir, route, 'index.html')
+      await fse.outputFile(output, replacedHtml)
+      console.log('Wrote: ' + output)
+    })
+  )
+}
+
+generatePages({
+  baseHtmlPath: './dist/index.html',
+  outputDir: './dist',
+  routes: () => {
+    return new Promise((resolve) => {
+      db.ref('illusts').once('value', (snapshot) => {
+        const routes = ['/']
+        snapshot.forEach((ref) => {
+          routes.push('/' + ref.key)
+        })
+        resolve(routes)
+      })
+    })
+  },
+})
+  .then(() => {
+    console.log('Done.')
+    process.exit(0)
+  })
+  .catch((e: any) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/package.json
+++ b/package.json
@@ -3,27 +3,30 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "generate": "vite build --ssr -c vite.config.ssr.ts && ts-node -O '{\"module\":\"commonjs\"}' -T generate.ts"
   },
   "dependencies": {
     "firebase": "^7.14.2",
     "jump.js": "^1.0.2",
     "tailwindcss": "^1.4.5",
-    "vue": "^3.0.0-beta.13",
-    "vue-class-component": "^8.0.0-alpha.5",
+    "vue": "^3.0.0-beta.14",
+    "vue-class-component": "^8.0.0-alpha.6",
     "vue-router": "^4.0.0-alpha.11"
   },
   "devDependencies": {
     "@google-cloud/storage": "^4.7.0",
     "@types/jump.js": "^1.0.3",
-    "@vue/compiler-sfc": "^3.0.0-beta.13",
+    "@vue/compiler-sfc": "^3.0.0-beta.14",
+    "@vue/server-renderer": "^3.0.0-beta.14",
     "eslint": "^6.8.0",
     "eslint-config-ktsn-vue": "^2.0.0",
     "firebase-admin": "^8.12.0",
     "fs-extra": "^9.0.0",
     "prettier": "^2.0.5",
     "sharp": "^0.25.2",
+    "ts-node": "^8.10.1",
     "typescript": "^3.8.3",
-    "vite": "^0.15.3"
+    "vite": "^0.16.0"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,7 @@
 <template>
-  <router-view />
+  <div>
+    <router-view />
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/components/VImage.vue
+++ b/src/components/VImage.vue
@@ -2,17 +2,43 @@
   <picture>
     <source :srcset="src" type="image/webp" />
     <source :srcset="srcFallback" />
-    <img :src="srcFallback" v-bind="$attrs" />
+    <img v-load="onLoad" :src="srcFallback" v-bind="$attrs" />
   </picture>
 </template>
 
 <script lang="ts">
 import { Vue, Options } from 'vue-class-component'
+import { Directive } from 'vue'
 
-class VImage extends Vue {}
+/**
+ * FIXME: using directive because HTMLElement is not injected into $refs on hydration sometimes.
+ */
+const load: Directive<HTMLImageElement> = {
+  mounted(el, { value }) {
+    if (el.complete) {
+      value()
+    }
+
+    el.addEventListener('load', value)
+  },
+
+  unmounted(el, { value }) {
+    el.removeEventListener('load', value)
+  },
+}
+
+class VImage extends Vue {
+  onLoad() {
+    this.$emit('isoload')
+  }
+}
 
 export default Options({
   name: 'VImage',
+
+  directives: {
+    load,
+  },
 
   props: {
     src: {

--- a/src/components/VLink.vue
+++ b/src/components/VLink.vue
@@ -1,0 +1,19 @@
+<template>
+  <a
+    class="text-gray-600 hover:text-gray-900 transition duration-200 ease-out"
+    v-bind="$attrs"
+  >
+    <slot />
+  </a>
+</template>
+
+<script lang="ts">
+import { Vue, Options } from 'vue-class-component'
+
+class VLink extends Vue {}
+
+export default Options({
+  name: 'VLink',
+  inheritAttrs: false,
+})(VLink)
+</script>

--- a/src/components/VRouterLink.vue
+++ b/src/components/VRouterLink.vue
@@ -1,20 +1,19 @@
 <template>
-  <component
-    :is="$attrs.to ? 'router-link' : 'a'"
+  <router-link
     class="text-gray-600 hover:text-gray-900 transition duration-200 ease-out"
     v-bind="$attrs"
   >
     <slot />
-  </component>
+  </router-link>
 </template>
 
 <script lang="ts">
 import { Vue, Options } from 'vue-class-component'
 
-class VTextLink extends Vue {}
+class VRouterLink extends Vue {}
 
 export default Options({
-  name: 'VTextLink',
+  name: 'VRouterLink',
   inheritAttrs: false,
-})(VTextLink)
+})(VRouterLink)
 </script>

--- a/src/components/VThumbnail.vue
+++ b/src/components/VThumbnail.vue
@@ -9,15 +9,19 @@
       enter-from-class="opacity-0"
       enter-to-class="opacity-100"
     >
-      <VImage
+      <div
         v-show="manager.allLoaded"
-        v-bind="$attrs"
-        class="absolute inset-0 w-full h-full object-cover"
+        class="absolute inset-0"
         :style="{ transitionDelay: appearDelay + 'ms' }"
-        :src="src"
-        :src-fallback="srcFallback"
-        @load="manager.loaded()"
-      />
+      >
+        <VImage
+          v-bind="$attrs"
+          class="absolute inset-0 w-full h-full object-cover"
+          :src="src"
+          :src-fallback="srcFallback"
+          @isoload="manager.loaded()"
+        />
+      </div>
     </transition>
   </div>
 </template>

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,1 @@
+export const inBrowser = typeof window !== 'undefined'

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -30,6 +30,8 @@ const firebaseConfig = __DEV__
 if (!firebase.apps.length) {
   firebase.initializeApp(firebaseConfig)
 }
-firebase.analytics()
+if (firebase.analytics) {
+  firebase.analytics()
+}
 
 export const db = firebase.database()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,25 @@
 import './main.css'
 import './lifecycle'
-import { createApp } from 'vue'
-import { router } from './router'
+import { createApp as createClientApp, createSSRApp } from 'vue'
+import { createRouter } from './router'
 import App from './App.vue'
+import { inBrowser } from './env'
 
-const app = createApp(App)
+export function createApp(isSsr = false) {
+  const router = createRouter(isSsr)
+  const app = __DEV__ ? createClientApp(App) : createSSRApp(App)
 
-app.use(router)
+  app.use(router)
 
-app.mount('#app')
+  return {
+    app,
+    router,
+  }
+}
+
+if (inBrowser) {
+  const { app, router } = createApp()
+  router.isReady().then(() => {
+    app.mount('#app')
+  })
+}

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,7 +1,8 @@
 <template>
   <template v-if="!illusts.loading">
     <header class="flex px-5 lg:px-10 pt-2 mb-5 w-full">
-      <ul>
+      <!-- FIXME: hide this area as it somehow causes hydration mismatch -->
+      <ul v-if="isMounted">
         <li v-for="(link, i) in illustLinks" :key="link" class="inline-block">
           <VRouterLink
             :to="'#year_' + link"
@@ -96,6 +97,7 @@ import { useIllusts, Illust } from '../composables/illusts'
 
 class Home extends Vue {
   illusts = setup(useIllusts)
+  isMounted = false
 
   get illustLinks() {
     return Array.from(this.illustGroups.keys()).sort((a, b) => b - a)
@@ -121,6 +123,10 @@ class Home extends Vue {
       })
 
     return groups
+  }
+
+  mounted() {
+    this.isMounted = true
   }
 
   onClickAnchor(to: string) {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -3,12 +3,12 @@
     <header class="flex px-5 lg:px-10 pt-2 mb-5 w-full">
       <ul>
         <li v-for="(link, i) in illustLinks" :key="link" class="inline-block">
-          <VTextLink
+          <VRouterLink
             :to="'#year_' + link"
             @click.prevent="onClickAnchor('#year_' + link)"
           >
             {{ link }}
-          </VTextLink>
+          </VRouterLink>
 
           <span v-if="i < illustLinks.length - 1" class="px-1">/</span>
         </li>
@@ -16,34 +16,37 @@
 
       <ul class="ml-auto">
         <li class="inline-block">
-          <VTextLink
-            href="https://github.com/ktsn/illust.ktsn.dev"
-            target="_blank"
-          >
-            <img
-              class="inline aline-middle mr-1"
-              src="../assets/github.svg"
-              width="20"
-              height="20"
-              alt="GitHub logo"
-            />
+          <VLink href="https://github.com/ktsn/illust.ktsn.dev" target="_blank">
+            <!--
+              FIXME: hide this as SSR build cannot handle it
+              <img
+                class="inline aline-middle mr-1"
+                src="../assets/github.svg"
+                width="20"
+                height="20"
+                alt="GitHub logo"
+              />
+            -->
             <span class="align-middle">Source</span>
-          </VTextLink>
+          </VLink>
 
           <span class="px-2 align-middle">/</span>
         </li>
 
         <li class="inline-block">
-          <VTextLink href="https://twitter.com/ktsn" target="_blank">
-            <img
-              class="inline aline-middle mr-1"
-              src="../assets/twitter.svg"
-              width="20"
-              height="20"
-              alt="Twitter logo"
-            />
+          <VLink href="https://twitter.com/ktsn" target="_blank">
+            <!--
+              FIXME: hide this as SSR build cannot handle it
+              <img
+                class="inline aline-middle mr-1"
+                src="../assets/twitter.svg"
+                width="20"
+                height="20"
+                alt="Twitter logo"
+              />
+            -->
             <span class="align-middle">Author</span>
-          </VTextLink>
+          </VLink>
         </li>
       </ul>
     </header>
@@ -85,7 +88,8 @@
 <script lang="ts">
 import { Vue, Options, setup } from 'vue-class-component'
 import jump from 'jump.js'
-import VTextLink from '../components/VTextLink.vue'
+import VRouterLink from '../components/VRouterLink.vue'
+import VLink from '../components/VLink.vue'
 import VThumbnail from '../components/VThumbnail.vue'
 import VThumbnailGroup from '../components/VThumbnailGroup.vue'
 import { useIllusts, Illust } from '../composables/illusts'
@@ -128,7 +132,8 @@ export default Options({
   name: 'Home',
 
   components: {
-    VTextLink,
+    VRouterLink,
+    VLink,
     VThumbnail,
     VThumbnailGroup,
   },

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -88,6 +88,7 @@
 
 <script lang="ts">
 import { Vue, Options, setup } from 'vue-class-component'
+import { watch } from 'vue'
 import jump from 'jump.js'
 import VRouterLink from '../components/VRouterLink.vue'
 import VLink from '../components/VLink.vue'
@@ -127,6 +128,21 @@ class Home extends Vue {
 
   mounted() {
     this.isMounted = true
+  }
+
+  serverPrefetch() {
+    const illust = useIllusts()
+    if (!illust.loading.value) {
+      return Promise.resolve()
+    }
+
+    return new Promise((resolve) => {
+      watch(illust.loading, (value) => {
+        if (!value) {
+          resolve()
+        }
+      })
+    })
   }
 
   onClickAnchor(to: string) {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -66,8 +66,8 @@
         class="grid gap-1 grid-flow-row xl:grid-cols-6 lg:grid-cols-5 md:grid-cols-4 sm:grid-cols-3 grid-cols-2"
       >
         <VThumbnailGroup>
-          <li v-for="(illust, index) in group" :key="index">
-            <router-link class="block" :to="'/' + illust.key">
+          <li v-for="(illust, index) in group" :key="illust.key">
+            <router-link class="block" :to="'/' + illust.key + '/'">
               <VThumbnail
                 :src="illust.thumbnailUrl"
                 :src-fallback="illust.thumbnailFallbackUrl"

--- a/src/pages/Illust.vue
+++ b/src/pages/Illust.vue
@@ -45,14 +45,14 @@
             <div
               v-if="!displayImageLoaded"
               v-show="thumbnailImageLoaded"
-              class="absolute inset-0 w-full h-full blur"
+              class="absolute inset-0 blur"
             >
               <VImage
                 class="absolute inset-0 w-full h-full object-contain"
                 :src="illust.result.thumbnailUrl"
                 :src-fallback="illust.result.thumbnailFallbackUrl"
                 alt=""
-                @load="thumbnailImageLoaded = true"
+                @isoload="thumbnailImageLoaded = true"
               />
             </div>
           </transition>
@@ -61,14 +61,15 @@
             enter-active-class="transition duration-500 ease-out"
             enter-from-class="opacity-0"
           >
-            <VImage
-              v-show="displayImageLoaded"
-              class="absolute inset-0 w-full h-full object-contain"
-              :src="illust.result.displayUrl"
-              :src-fallback="illust.result.displayFallbackUrl"
-              alt=""
-              @load="displayImageLoaded = true"
-            />
+            <div v-show="displayImageLoaded" class="absolute inset-0">
+              <VImage
+                class="absolute inset-0 w-full h-full object-contain"
+                :src="illust.result.displayUrl"
+                :src-fallback="illust.result.displayFallbackUrl"
+                alt=""
+                @isoload="displayImageLoaded = true"
+              />
+            </div>
           </transition>
         </div>
       </router-link>
@@ -99,7 +100,10 @@ class Illust extends Vue {
   leaving: boolean = false
 
   beforeRouteLeave(_to: unknown, _from: unknown, next: () => void) {
-    this.leaving = true
+    // FIXME: Sometimes this becomes undefined...
+    if (this) {
+      this.leaving = true
+    }
     next()
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,30 +1,70 @@
-import { createRouter, createWebHistory, Router } from 'vue-router'
+import {
+  createRouter as _createRouter,
+  createWebHistory,
+  createMemoryHistory,
+  Router,
+} from 'vue-router'
 import Home from './pages/Home.vue'
 import Illust from './pages/Illust.vue'
+import { inBrowser } from './env'
 
-export const router = createRouter({
-  history: createWebHistory(),
+export function createRouter(_isSsr: boolean) {
+  const router = _createRouter({
+    history: inBrowser ? createWebHistory() : createMemoryHistory(),
 
-  routes: [
-    {
-      name: 'home',
-      path: '/',
-      component: Home,
-      children: [
-        {
-          name: 'illust',
-          path: ':illustKey',
-          component: Illust,
-          props: true,
-        },
-      ],
-    },
-    {
-      path: '/:catchAll(.*)',
-      redirect: '/',
-    },
-  ],
-})
+    routes: [
+      {
+        name: 'home',
+        path: '/',
+        component: Home,
+        children: [
+          {
+            name: 'illust',
+            path: ':illustKey/',
+            component: Illust,
+            props: true,
+          },
+        ],
+      },
+      {
+        path: '/:catchAll(.*)',
+        redirect: '/',
+      },
+    ],
+  })
+
+  router.beforeResolve(async (to, _from, next) => {
+    const matched = to.matched
+    Promise.all(
+      matched.map((m) => {
+        const comps = Object.keys(m.components).map((key) => {
+          const c = m.components[key]
+          return (c as any).__vccOpts ?? c
+        })
+
+        return Promise.all(
+          comps.map(async (options) => {
+            const { serverPrefetch } = options
+            if (!serverPrefetch) {
+              return
+            }
+
+            await serverPrefetch()
+          })
+        )
+      })
+    ).then(
+      () => {
+        next()
+      },
+      (error) => {
+        next(error)
+      }
+    )
+  })
+
+  return router
+}
 
 declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {

--- a/vite.config.ssr.ts
+++ b/vite.config.ssr.ts
@@ -1,0 +1,30 @@
+import { UserConfig } from 'vite'
+
+const config: UserConfig = {
+  alias: {
+    'firebase/analytics': require.resolve('./dummy.js'),
+  },
+
+  vueCompilerOptions: {
+    directiveTransforms: {
+      load: () => {
+        return {
+          props: [],
+        }
+      },
+    },
+  },
+
+  rollupInputOptions: {
+    input: {
+      app: './src/main.ts',
+    },
+    preserveEntrySignatures: 'allow-extension',
+    external: ['firebase/app', 'firebase/database'],
+    treeshake: {
+      moduleSideEffects: true,
+    },
+  },
+}
+
+export default config

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,53 +664,34 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vue/compiler-core@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-beta.12.tgz#1d9bfeeedd7fb9fd8181e762b8c42568e9caf69c"
-  integrity sha512-+UjGiEo/RLx7yaAUfSuhZCvXypV85CKgVERXvtL/yOLd+3Y37Z7d5Qwnsej3S4NPvhvHNUFplhU1P1LOucw0pg==
+"@vue/compiler-core@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-beta.14.tgz#69019b5c3da8335e6d83f81b37648caf120dbacd"
+  integrity sha512-VZarslk2r0E8V9Iuu24LPOWuomWV8KgTp3Pmie6Ys+LnIk+G/hme9BwC2jZgmqgF+adwcfmUC5BTi/KbhRVeIw==
   dependencies:
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/shared" "3.0.0-beta.14"
     estree-walker "^0.8.1"
     source-map "^0.6.1"
 
-"@vue/compiler-core@3.0.0-beta.13":
-  version "3.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-beta.13.tgz#032e030860fa3bf83857d7098554d6b89f9fc9f2"
-  integrity sha512-OK4Lq12zeCaaYiPMcG7/QaMFgznxFu7+ai1JK6/iwkKFXX5DwgDDfF+JQ6Rf+gA2hZDrgaZIrWT4tvpRHG59Kw==
+"@vue/compiler-dom@3.0.0-beta.14", "@vue/compiler-dom@^3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-beta.14.tgz#2ea1c165e06e9630e687a7a5cbde4e8b20b064ac"
+  integrity sha512-wZ2uWo4jvAGD5FPNZYMOxpKEDigLcoPvOGhIAv8H4B6ltDyW54Zfc4RrW5MopJqEcHDDZMpcgGcFN5Qa09sLOg==
   dependencies:
-    "@babel/parser" "^7.8.6"
-    "@babel/types" "^7.8.6"
-    "@vue/shared" "3.0.0-beta.13"
-    estree-walker "^0.8.1"
-    source-map "^0.6.1"
+    "@vue/compiler-core" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
 
-"@vue/compiler-dom@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-beta.12.tgz#f455898b96d421d71c808ca35b8349504a2f7ffd"
-  integrity sha512-HEirNEGczvMep3suCZO91q/1x5wEO0y0MvZJ51HJL2UZBSUjBSp/8ilBVWpOoOYC6mYVoxEIm1Jv9AoSsOipzQ==
+"@vue/compiler-sfc@^3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.0-beta.14.tgz#3984416c0ed1bbdfbeee9d33c8a2c1152ed00770"
+  integrity sha512-pS/vTlLWBEkyyA2oZBQHqqObaLEy25BKX9LzNphDBC+zKRufGQEObecwSbJK2QGdu8/bzxI3sAJvBlPm8ZmDOA==
   dependencies:
-    "@vue/compiler-core" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
-
-"@vue/compiler-dom@3.0.0-beta.13":
-  version "3.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-beta.13.tgz#865561d33321093ae4de3f65a2e277a767c6f7f6"
-  integrity sha512-8XEId6xa5T7S5uTFcKSDL60dTzz7/jiKqmznnnc8T4IBL3kbATGnFqtda3dCZwu5M6g2+0XGdjI7xLbAtf0l1Q==
-  dependencies:
-    "@vue/compiler-core" "3.0.0-beta.13"
-    "@vue/shared" "3.0.0-beta.13"
-
-"@vue/compiler-sfc@^3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.0-beta.12.tgz#ed93aa0f07d5d099cea7582118e05fbb7c77b1c6"
-  integrity sha512-YtX7SJdk68eKPwcL0u515MjOerMSao5UrM0EtL5zxLlQUiokmqxddxALEM28C62CoUonAWr8CWqnb262u0DBoA==
-  dependencies:
-    "@vue/compiler-core" "3.0.0-beta.12"
-    "@vue/compiler-dom" "3.0.0-beta.12"
-    "@vue/compiler-ssr" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/compiler-core" "3.0.0-beta.14"
+    "@vue/compiler-dom" "3.0.0-beta.14"
+    "@vue/compiler-ssr" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
     consolidate "^0.15.1"
     hash-sum "^2.0.0"
     lru-cache "^5.1.1"
@@ -720,97 +701,50 @@
     postcss-selector-parser "^6.0.2"
     source-map "^0.6.1"
 
-"@vue/compiler-sfc@^3.0.0-beta.13":
-  version "3.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.0-beta.13.tgz#131cfda84489141889ec76cd2c9371fa3a118d2b"
-  integrity sha512-wAjwSSf5j/DUIO2ugBdHlYJxw7GXdO1tF1upo7kDOJft+qCUThuhsg6rsxVN+zZ+dmiqBf/Yj9u4RjDRHXkeLw==
+"@vue/compiler-ssr@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.0-beta.14.tgz#e5a0dc1afcaf4f110e2e447b41bb3d8172e3e3e9"
+  integrity sha512-u5NquoX/EgmY40PICZoOA+CBzQNkYW0IhrTiqzN2BivUAO4PM3L0jesAFTbVX5CQ6eGJn1jGjBuuEks2IkJzsw==
   dependencies:
-    "@vue/compiler-core" "3.0.0-beta.13"
-    "@vue/compiler-dom" "3.0.0-beta.13"
-    "@vue/compiler-ssr" "3.0.0-beta.13"
-    "@vue/shared" "3.0.0-beta.13"
-    consolidate "^0.15.1"
-    hash-sum "^2.0.0"
-    lru-cache "^5.1.1"
-    merge-source-map "^1.1.0"
-    postcss "^7.0.27"
-    postcss-modules "^2.0.0"
-    postcss-selector-parser "^6.0.2"
-    source-map "^0.6.1"
+    "@vue/compiler-dom" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
 
-"@vue/compiler-ssr@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.0-beta.12.tgz#ba935628ca2c917e8114b24d95ebfaf345136eb1"
-  integrity sha512-e1HRCQn5wCOQpcjLWUMyWPzKQSFmn2Sn0ZuhXPBsK1IlR1ElFOK6EC/EUHGwz3piFWZpuqpEWX7+0B9AYWNJAg==
+"@vue/reactivity@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-beta.14.tgz#a041ec24ce2e545583a6a1a42774311c16870a91"
+  integrity sha512-csqLljnM+8OBBAyzeUXGIYJhhph0DLOsHQwJGmz7uc342taW6XSi4MXaLk5MRiigunfmXxEswJGziwsh+4YP3g==
   dependencies:
-    "@vue/compiler-dom" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/shared" "3.0.0-beta.14"
 
-"@vue/compiler-ssr@3.0.0-beta.13":
-  version "3.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.0-beta.13.tgz#f2556f23487f0a2f0edd8dfb87f5234b5815768e"
-  integrity sha512-nv47vmbjyFCuLr2hK6Rbvts6M+Zh6yoroeSEUxPYl9P82oFYUvmgExYwqW+uoNiTtUmb8lqfVI1d8kNCipeZwA==
+"@vue/runtime-core@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-beta.14.tgz#4f8162befd6ad1ac55cc6c142edc8301b090658a"
+  integrity sha512-5WKNMd7lX0vdSMeNd1cF0VhM+N+kXicSXKKZtTfQLUfZt1gLuE3nlBhv1PqjGf79zXw5lQLzz6XoUY1i52rEkA==
   dependencies:
-    "@vue/compiler-dom" "3.0.0-beta.13"
-    "@vue/shared" "3.0.0-beta.13"
+    "@vue/reactivity" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
 
-"@vue/reactivity@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-beta.12.tgz#33e8c3845dc663967c85217316f831a0153c40dc"
-  integrity sha512-ZgqLVADzwgFvm+Jf12bfzesvV3wcZXfM6JmryZ2BrWvkGS+Xo0A4oOcnsB4Tmqw5lemdYYkoleup02ChzvRlMg==
+"@vue/runtime-dom@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-beta.14.tgz#080e9dd48a95da639f9fcc6d70a2d9620aec6ab8"
+  integrity sha512-nwHvG+IsO0Ttl39NPvQKX2vv5H4XWZVzZCX1rqEIBP3llHyyB9dMrNSPcw54YlPGrEuCwBxVDokHG4CSeVEdtg==
   dependencies:
-    "@vue/shared" "3.0.0-beta.12"
-
-"@vue/reactivity@3.0.0-beta.13":
-  version "3.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-beta.13.tgz#9c12a95d3ff2b110b13e9f0b788ccbc65608305e"
-  integrity sha512-hP/Qa2LIyJA0UNq1+eyFRTyPXarZcdCtxLLlWziXbeoe/GgO6FWivnkDmVSJ5CqWE8ptw0cXDx/htUSn7P/u/g==
-  dependencies:
-    "@vue/shared" "3.0.0-beta.13"
-
-"@vue/runtime-core@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-beta.12.tgz#f35fa386c319e13da682e58f171e25c2376ec865"
-  integrity sha512-qcgfp5VJCuObGIYPoust7l3hZONHfgJfVeVYPjaKi+asjlYwdmjTRExUahhjuHvkLdSGRY+qckS3Adga7kyMjg==
-  dependencies:
-    "@vue/reactivity" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
-
-"@vue/runtime-core@3.0.0-beta.13":
-  version "3.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-beta.13.tgz#b5b07c905a6f0a4b2456f764b4783c074776ab67"
-  integrity sha512-1TjBuchquwBbC2wp+Zt4ZnsKlkoSgKepHZhJyQAkLH5JOe/w4yFcIjlwFnaVJ2BIB/n7EBRheilNmhPVUiC5ng==
-  dependencies:
-    "@vue/reactivity" "3.0.0-beta.13"
-    "@vue/shared" "3.0.0-beta.13"
-
-"@vue/runtime-dom@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-beta.12.tgz#f9c0f02fb2152727ec0746517ae5ab08513d00e8"
-  integrity sha512-1fyDeKKX2KMZbMmxn9a/QzwYSlbzZlGz3Iy9iss/WbFFK9hNtAEWY6x4iwtw7/vJ00EE8OOMgHX3ki9fNNqSqw==
-  dependencies:
-    "@vue/runtime-core" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/runtime-core" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
     csstype "^2.6.8"
 
-"@vue/runtime-dom@3.0.0-beta.13":
-  version "3.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-beta.13.tgz#d1c451d1af009cd7c1238c9bb8017d4785cac33d"
-  integrity sha512-UzkVkvcOzJq7nB2fOd5aMqzowLzUI3/hPhFrBDuhb5kguAOEJJI5EF4a/6J1LSYyHjqWUZNgSR0ZVdwLzWTq/Q==
+"@vue/server-renderer@^3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.0.0-beta.14.tgz#3311e145466e68e7050d6211c3f6d72d2777b1ea"
+  integrity sha512-Wpt2hlrVu3L66/WFX6cnqCUr68wcHhaR6IiVDgnOUQW/SyVJPCKpSsnuB+4Y6VmiKbINBWBG/rG3TVC/yiFi1w==
   dependencies:
-    "@vue/runtime-core" "3.0.0-beta.13"
-    "@vue/shared" "3.0.0-beta.13"
-    csstype "^2.6.8"
+    "@vue/compiler-ssr" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
 
-"@vue/shared@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-beta.12.tgz#cb7a2bb047919d2c944bf822032b0a8aa869ba1d"
-  integrity sha512-cA0DD3VFGYI76lbM90fAYXNJ9EmDNsm1tthO4FIY18DwziZKJWCfQBhEfHQd2skHcTE4OqH5eBxgsKEdn/LuGQ==
-
-"@vue/shared@3.0.0-beta.13":
-  version "3.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-beta.13.tgz#5ee01f8827c610494f1bab023a9e2fb7f9ed60cf"
-  integrity sha512-93g7tJH6tziqITygPh24XDJWnjrROI0wftCfFLSQu2hWoyd6OA5bdJI2n3HFv382o2sqMptGDXouKJRsQxMLmw==
+"@vue/shared@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-beta.14.tgz#886afe5c233a5b255c186142324c40f114958af5"
+  integrity sha512-mnK5teJMLzsBE56Kys+uiyR/jAl1kbokHZ++MnlP7ls9icPqZ/QQE/VTDl3QJ7IHteS2VR6ytAz/Aa/4Dpv/ew==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -950,6 +884,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1594,7 +1533,7 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^3.1.0:
+debug@^3.0.0, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1709,6 +1648,11 @@ dicer@^0.3.0:
   integrity sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==
   dependencies:
     streamsearch "0.1.2"
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -2097,7 +2041,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-etag@^1.3.0:
+etag@^1.3.0, etag@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
@@ -2106,6 +2050,11 @@ event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
+eventemitter3@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
+  integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
 
 execa@^4.0.1:
   version "4.0.1"
@@ -2253,6 +2202,13 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+follow-redirects@^1.0.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.11.0.tgz#afa14f08ba12a52963140fe43212658897bc0ecb"
+  integrity sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==
+  dependencies:
+    debug "^3.0.0"
 
 foreach@^2.0.5:
   version "2.0.5"
@@ -2569,6 +2525,14 @@ http-errors@^1.6.3, http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+http-errors@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.4.0.tgz#6c0242dea6b3df7afda153c71089b31c6e82aabf"
+  integrity sha1-bAJC3qaz33r9oVPHEImzHG6Cqr8=
+  dependencies:
+    inherits "2.0.1"
+    statuses ">= 1.2.1 < 2"
+
 http-errors@~1.6.2:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
@@ -2592,6 +2556,15 @@ http-proxy-agent@^4.0.0:
     "@tootallnate/once" "1"
     agent-base "6"
     debug "4"
+
+http-proxy@^1.16.2:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
 
 https-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -2685,6 +2658,11 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
 inherits@2.0.3:
   version "2.0.3"
@@ -2938,6 +2916,11 @@ is-wsl@^2.1.1:
   dependencies:
     is-docker "^2.0.0"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
@@ -3132,6 +3115,14 @@ koa-etag@^3.0.0:
     etag "^1.3.0"
     mz "^2.1.0"
 
+koa-proxies@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/koa-proxies/-/koa-proxies-0.11.0.tgz#43dde4260080f7cb0f284655f85cf654bbe9ec84"
+  integrity sha512-iXGRADBE0fM7g7AttNOlLZ/cCFKXeVMHbFJKIRb0dUCrSYXi02loyVSdBlKlBQ5ZfVKJLo9Q9FyqwVTp1poVVA==
+  dependencies:
+    http-proxy "^1.16.2"
+    path-match "^1.2.4"
+
 koa-send@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/koa-send/-/koa-send-5.0.0.tgz#5e8441e07ef55737734d7ced25b842e50646e7eb"
@@ -3313,6 +3304,11 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 mdn-data@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
@@ -3345,7 +3341,7 @@ mime-db@1.44.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-mime-types@^2.0.8, mime-types@^2.1.18, mime-types@~2.1.24:
+mime-types@^2.0.8, mime-types@^2.1.18, mime-types@^2.1.27, mime-types@~2.1.24:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
@@ -3748,10 +3744,25 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-match@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/path-match/-/path-match-1.2.4.tgz#a62747f3c7e0c2514762697f24443585b09100ea"
+  integrity sha1-pidH88fgwlFHYml/JEQ1hbCRAOo=
+  dependencies:
+    http-errors "~1.4.0"
+    path-to-regexp "^1.0.0"
+
 path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@^1.0.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
@@ -4355,6 +4366,11 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
@@ -4424,10 +4440,10 @@ rollup-plugin-terser@^5.3.0:
     serialize-javascript "^2.1.2"
     terser "^4.6.2"
 
-rollup-plugin-vue@^6.0.0-alpha.10:
-  version "6.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0-alpha.10.tgz#0fbe33f2e3d9f13c392a1eef0c421aa9cc218bb6"
-  integrity sha512-10GOFWTGMrX0pkG4AlkiyElhpQi2bSGD/Zed8IycRmpf7vO8NRm5hf+KM+uLGeZjPck1NNnQoUf6kPYCZ0CZAA==
+rollup-plugin-vue@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0-beta.1.tgz#6334f3d76867f761623ba34c54a34a58a8d7ed24"
+  integrity sha512-jML9JYr+ZMQ1xUfMSgNzJ5kcv0kM+js9DJNBrUmvp1Lhydx8X4b3VOtybr0Dch5V3hUeBdxtKQgopadBnY9axA==
   dependencies:
     debug "^4.1.1"
     hash-sum "^2.0.0"
@@ -4611,7 +4627,7 @@ snakeize@^0.1.0:
   resolved "https://registry.yarnpkg.com/snakeize/-/snakeize-0.1.0.tgz#10c088d8b58eb076b3229bb5a04e232ce126422d"
   integrity sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0=
 
-source-map-support@~0.5.12:
+source-map-support@^0.5.17, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -4644,7 +4660,7 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
-"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0:
+"statuses@>= 1.2.1 < 2", "statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -5019,6 +5035,17 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+ts-node@^8.10.1:
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.1.tgz#77da0366ff8afbe733596361d2df9a60fc9c9bd3"
+  integrity sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 tslib@1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
@@ -5187,17 +5214,18 @@ vendors@^1.0.0:
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e"
   integrity sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==
 
-vite@^0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-0.15.3.tgz#b1ec491e6ddebf7489dcd56b7138e334817660c5"
-  integrity sha512-w4/WObJPyUsj6JAAEySy/uovxhER0g2weIfBliFOiEWXbK8WCuqNf5mrSB/h15AvTqPxO5FSYZVRHC0Vro0DVQ==
+vite@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-0.16.0.tgz#c27317b66c44685d4cd19c2dd81d7953ac5cad04"
+  integrity sha512-JBgdl2qwfcgGciBYo/duMqjuQEFaH/Fwx5rGeEMIz/DxsaHEjscK8xigYfzvZ+UVnoC+VtmnnTGW5RiP3SCkLg==
   dependencies:
     "@babel/parser" "^7.9.4"
     "@rollup/plugin-commonjs" "~11.0.0"
     "@rollup/plugin-json" "^4.0.3"
     "@rollup/plugin-node-resolve" "^7.1.3"
     "@types/koa" "^2.11.3"
-    "@vue/compiler-sfc" "^3.0.0-beta.12"
+    "@vue/compiler-dom" "^3.0.0-beta.14"
+    "@vue/compiler-sfc" "^3.0.0-beta.14"
     brotli-size "^4.0.0"
     chalk "^4.0.0"
     chokidar "^3.3.1"
@@ -5205,16 +5233,19 @@ vite@^0.15.3:
     debug "^4.1.1"
     es-module-lexer "^0.3.18"
     esbuild "^0.3.2"
+    etag "^1.8.1"
     execa "^4.0.1"
     fs-extra "^9.0.0"
     hash-sum "^2.0.0"
     koa "^2.11.0"
     koa-conditional-get "^2.0.0"
     koa-etag "^3.0.0"
+    koa-proxies "^0.11.0"
     koa-send "^5.0.0"
     koa-static "^5.0.0"
     lru-cache "^5.1.1"
     magic-string "^0.25.7"
+    mime-types "^2.1.27"
     minimist "^1.2.5"
     open "^7.0.3"
     ora "^4.0.4"
@@ -5223,15 +5254,15 @@ vite@^0.15.3:
     postcss-modules "^2.0.0"
     rollup "^2.7.2"
     rollup-plugin-terser "^5.3.0"
-    rollup-plugin-vue "^6.0.0-alpha.10"
+    rollup-plugin-vue "^6.0.0-beta.1"
     slash "^3.0.0"
-    vue "^3.0.0-beta.12"
+    vue "^3.0.0-beta.14"
     ws "^7.2.3"
 
-vue-class-component@^8.0.0-alpha.5:
-  version "8.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-8.0.0-alpha.5.tgz#8fa9554fb329c9b30ae33e6ab001551e817140c8"
-  integrity sha512-QfYU9hP+nHMb82ucSwig0Nm9EdtRB0X4ka3Y4Drq2ii0Kt/MCfVv146q2d5o/dhvVGYhjWX2DtG6X0hmr1W9xg==
+vue-class-component@^8.0.0-alpha.6:
+  version "8.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-8.0.0-alpha.6.tgz#395ec86e58001680306278fcef60e1ffe705a5bd"
+  integrity sha512-bxugtly8bzgt0du09LjJnK6X5v8nhMi5ABw4KKy50Rv/UdaAZDCrThp6kBbtBXocMf4EnhlfRVf/N4g4CPDc/Q==
 
 vue-eslint-parser@^5.0.0:
   version "5.0.0"
@@ -5250,23 +5281,14 @@ vue-router@^4.0.0-alpha.11:
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.0.0-alpha.11.tgz#17b0f31ae6b0284ee0895b03904cf1738989aa0e"
   integrity sha512-GEgKq7rlwdv03QcGqADZg+Es8D6R8FfZRLSj0Ardx/sK8PiIxpt5ViwW94Zh2LuIEiuM1U5v8iyTBya0UBK61g==
 
-vue@^3.0.0-beta.12:
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-beta.12.tgz#e72d1baeede285768d2df0f2b52dc79427f49419"
-  integrity sha512-4Y8LPplndYp48q1P8CSbG3Et/bPcMQB11edusA6SuIGmgrLdS4Ntdwpjtc9kglYHaY9/E/VTVjl4jAGqpAFR1w==
+vue@^3.0.0-beta.14:
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-beta.14.tgz#d2c8739e00c4a4a06b519c14c57d204c350c980c"
+  integrity sha512-0MH1g5O3zX8ijvZuiQTYFq3UwHxtj512I/wrMPQLVXwjqb+ILA+fooSpdz4xgUBBl5zN/K9xJIwbl23sv+Sn7A==
   dependencies:
-    "@vue/compiler-dom" "3.0.0-beta.12"
-    "@vue/runtime-dom" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
-
-vue@^3.0.0-beta.13:
-  version "3.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-beta.13.tgz#a955c5f159bcf9183049b30a19918eb637ff386d"
-  integrity sha512-eXx9o1HKCrr2GV9SMpXd744E1nB47Lb4FbuzQwdNYvk4Bcjg6VP3nrInrFeWmKPoXW0VxRAperHje7RKwoei+A==
-  dependencies:
-    "@vue/compiler-dom" "3.0.0-beta.13"
-    "@vue/runtime-dom" "3.0.0-beta.13"
-    "@vue/shared" "3.0.0-beta.13"
+    "@vue/compiler-dom" "3.0.0-beta.14"
+    "@vue/runtime-dom" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
 
 walkdir@^0.4.0:
   version "0.4.1"
@@ -5424,3 +5446,8 @@ ylru@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ylru/-/ylru-1.2.1.tgz#f576b63341547989c1de7ba288760923b27fe84f"
   integrity sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Added `generated.ts` for static site generation. It will generates all pages as html files which are based on `index.html` Vite generates.

The generation is quite simple as it does not handle html meta, prefetch etc. But the perf of initial load is improved enough with it.

I've also changed some app codes with `FIXME` comment. They may be related with upstream library bug. Will investigate them later on this PR.