### PR TITLE
add rel="noopener" if the link is for external site

### DIFF
--- a/src/components/VLink.vue
+++ b/src/components/VLink.vue
@@ -1,6 +1,9 @@
 <template>
   <a
     class="text-gray-600 hover:text-gray-900 transition duration-200 ease-out"
+    :href="href"
+    :target="isExternal ? '_blank' : null"
+    :rel="isExternal ? 'noopener' : null"
     v-bind="$attrs"
   >
     <slot />
@@ -10,10 +13,23 @@
 <script lang="ts">
 import { Vue, Options } from 'vue-class-component'
 
-class VLink extends Vue {}
+class VLink extends Vue {
+  href!: string
+
+  get isExternal(): boolean {
+    return /^(?:https?:)?\/\//.test(this.href)
+  }
+}
 
 export default Options({
   name: 'VLink',
   inheritAttrs: false,
+
+  props: {
+    href: {
+      type: String,
+      required: true,
+    },
+  },
 })(VLink)
 </script>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -17,7 +17,7 @@
 
       <ul class="ml-auto">
         <li class="inline-block">
-          <VLink href="https://github.com/ktsn/illust.ktsn.dev" target="_blank">
+          <VLink href="https://github.com/ktsn/illust.ktsn.dev">
             <!--
               FIXME: hide this as SSR build cannot handle it
               <img
@@ -35,7 +35,7 @@
         </li>
 
         <li class="inline-block">
-          <VLink href="https://twitter.com/ktsn" target="_blank">
+          <VLink href="https://twitter.com/ktsn">
             <!--
               FIXME: hide this as SSR build cannot handle it
               <img


### PR DESCRIPTION
For security reason.
https://web.dev/external-anchors-use-rel-noopener/?